### PR TITLE
Fix to read correctly when inferred as Optional type

### DIFF
--- a/Sources/FileIO/FileIO.swift
+++ b/Sources/FileIO/FileIO.swift
@@ -54,6 +54,7 @@ public protocol _FileIOProtocol {
     func delete(offset: Int, length: Int) throws
 
     func read<T>(offset: Int) throws -> T
+    func read<T>(offset: Int, as: T.Type) throws -> T
     func write<T>(_ value: T, at offset: Int) throws
 }
 

--- a/Sources/FileIO/MemoryMappedFile.swift
+++ b/Sources/FileIO/MemoryMappedFile.swift
@@ -169,6 +169,7 @@ extension MemoryMappedFile {
 }
 
 extension MemoryMappedFile {
+    @_disfavoredOverload
     public func read<T>(offset: Int) throws -> T {
         let length = MemoryLayout<T>.size
         guard offset + length <= size else {
@@ -178,6 +179,17 @@ extension MemoryMappedFile {
             .assumingMemoryBound(to: T.self)
             .pointee
     }
+
+    public func read<T>(offset: Int) throws -> Optional<T> {
+        let length = MemoryLayout<T>.size
+        guard offset + length <= size else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        return ptr.advanced(by: offset)
+            .assumingMemoryBound(to: T.self)
+            .pointee
+    }
+
 
     public func write<T>(_ value: T, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
@@ -279,9 +291,20 @@ extension MemoryMappedFileSlice {
         self.size -= length
     }
 
+    @_disfavoredOverload
     public func read<T>(offset: Int) throws -> T {
         let length = MemoryLayout<T>.size
-        guard offset + length <= size else {
+        guard offset >= 0, length >= 0, offset + length <= size else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        return ptr.advanced(by: offset)
+            .assumingMemoryBound(to: T.self)
+            .pointee
+    }
+
+    public func read<T>(offset: Int) throws -> Optional<T> {
+        let length = MemoryLayout<T>.size
+        guard offset >= 0, length >= 0, offset + length <= size else {
             throw FileIOError.offsetOutOfBounds
         }
         return ptr.advanced(by: offset)

--- a/Sources/FileIO/MemoryMappedFile.swift
+++ b/Sources/FileIO/MemoryMappedFile.swift
@@ -171,16 +171,14 @@ extension MemoryMappedFile {
 extension MemoryMappedFile {
     @_disfavoredOverload
     public func read<T>(offset: Int) throws -> T {
-        let length = MemoryLayout<T>.size
-        guard offset + length <= size else {
-            throw FileIOError.offsetOutOfBounds
-        }
-        return ptr.advanced(by: offset)
-            .assumingMemoryBound(to: T.self)
-            .pointee
+        try read(offset: offset, as: T.self)
     }
 
     public func read<T>(offset: Int) throws -> Optional<T> {
+        try read(offset: offset, as: T.self)
+    }
+
+    public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
         guard offset + length <= size else {
             throw FileIOError.offsetOutOfBounds
@@ -189,7 +187,6 @@ extension MemoryMappedFile {
             .assumingMemoryBound(to: T.self)
             .pointee
     }
-
 
     public func write<T>(_ value: T, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
@@ -293,16 +290,14 @@ extension MemoryMappedFileSlice {
 
     @_disfavoredOverload
     public func read<T>(offset: Int) throws -> T {
-        let length = MemoryLayout<T>.size
-        guard offset >= 0, length >= 0, offset + length <= size else {
-            throw FileIOError.offsetOutOfBounds
-        }
-        return ptr.advanced(by: offset)
-            .assumingMemoryBound(to: T.self)
-            .pointee
+        try read(offset: offset, as: T.self)
     }
 
     public func read<T>(offset: Int) throws -> Optional<T> {
+        try read(offset: offset, as: T.self)
+    }
+
+    public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
         guard offset >= 0, length >= 0, offset + length <= size else {
             throw FileIOError.offsetOutOfBounds

--- a/Sources/FileIO/StreamedFile.swift
+++ b/Sources/FileIO/StreamedFile.swift
@@ -104,7 +104,16 @@ extension StreamedFile {
 }
 
 extension StreamedFile {
+    @_disfavoredOverload
     public func read<T>(offset: Int) throws -> T {
+        let length = MemoryLayout<T>.size
+        let data = try readData(offset: offset, length: length)
+        return data.withUnsafeBytes {
+            $0.load(as: T.self)
+        }
+    }
+
+    public func read<T>(offset: Int) throws -> Optional<T> {
         let length = MemoryLayout<T>.size
         let data = try readData(offset: offset, length: length)
         return data.withUnsafeBytes {
@@ -290,7 +299,16 @@ extension StreamedFileSlice {
         }
     }
 
+    @_disfavoredOverload
     public func read<T>(offset: Int) throws -> T {
+        let length = MemoryLayout<T>.size
+        let data = try readData(offset: offset, length: length)
+        return data.withUnsafeBytes {
+            $0.load(as: T.self)
+        }
+    }
+
+    public func read<T>(offset: Int) throws -> Optional<T> {
         let length = MemoryLayout<T>.size
         let data = try readData(offset: offset, length: length)
         return data.withUnsafeBytes {

--- a/Sources/FileIO/StreamedFile.swift
+++ b/Sources/FileIO/StreamedFile.swift
@@ -106,14 +106,14 @@ extension StreamedFile {
 extension StreamedFile {
     @_disfavoredOverload
     public func read<T>(offset: Int) throws -> T {
-        let length = MemoryLayout<T>.size
-        let data = try readData(offset: offset, length: length)
-        return data.withUnsafeBytes {
-            $0.load(as: T.self)
-        }
+        try read(offset: offset, as: T.self)
     }
 
     public func read<T>(offset: Int) throws -> Optional<T> {
+        try read(offset: offset, as: T.self)
+    }
+
+    public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
         let data = try readData(offset: offset, length: length)
         return data.withUnsafeBytes {
@@ -301,14 +301,14 @@ extension StreamedFileSlice {
 
     @_disfavoredOverload
     public func read<T>(offset: Int) throws -> T {
-        let length = MemoryLayout<T>.size
-        let data = try readData(offset: offset, length: length)
-        return data.withUnsafeBytes {
-            $0.load(as: T.self)
-        }
+        try read(offset: offset, as: T.self)
     }
 
     public func read<T>(offset: Int) throws -> Optional<T> {
+        try read(offset: offset, as: T.self)
+    }
+
+    public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
         let data = try readData(offset: offset, length: length)
         return data.withUnsafeBytes {


### PR DESCRIPTION
The following codes may not be read correctly.

```swift
guard let value: UInt64 = try? fileSlice.fileSlice(offset: 1000, length: 1000) else {
    return nil
}

// Same if generics are specified as follows
// guard let value: UInt64 = try? fileSlice.fileSlice<UInt64>(offset: 1000, length: 1000) else {
//     return nil
// }
```

Consider reading from a byte string containing the UInt64 type number 0x80100000000000000000.

```swift
let raw: UInt64 = 0x8010000000000000
let opt = Optional<UInt64>.some(raw)

let data = withUnsafeBytes(of: opt) { Data($0) }
```

In this case, the byte sequence when treated as UInt64 type and the byte sequence when treated as Optional<UInt64> are as follows.

```
UInt64 => [0,0,0,0,0,0,16,128]
Optional<UInt64> => [0,0,0,0,0,0,16,128,0]
```

It can be seen that the size of the larger byte is larger by one byte.

Consider the case where the next byte of 0x80100000000000000000 is 1.
In this case, what should be read as UInt64 is read as Optional<UInt64> by mistake.
```swift
Data([0,0,0,0,0,0,16,128,1])
    .withUnsafeBytes {
        $0.baseAddress!.assumingMemoryBound(to: Optional<UInt64>.self).pointee
    }
```

In this case, it is read as nil.
