### PR TITLE
Refactor guard statements to use _fastPath for performance improvements

### DIFF
--- a/Sources/FileIO/StreamedFile.swift
+++ b/Sources/FileIO/StreamedFile.swift
@@ -40,7 +40,9 @@ extension StreamedFile {
 
 extension StreamedFile {
     public func readData(offset: Int, length: Int) throws -> Data {
-        guard offset >= 0, length >= 0, offset + length <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         fileHandle.seek(toFileOffset: UInt64(offset))
@@ -49,7 +51,8 @@ extension StreamedFile {
 
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard offset >= 0, offset + data.count <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset + data.count <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         fileHandle.seek(toFileOffset: UInt64(offset))
@@ -72,13 +75,14 @@ extension StreamedFile {
 extension StreamedFile {
     public func resize(newSize: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard newSize > 0 else { return }
+        guard _fastPath(newSize > 0) else { return }
         fileHandle.truncateFile(atOffset: UInt64(newSize))
     }
 
     public func insertData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard offset >= 0, offset <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -92,7 +96,9 @@ extension StreamedFile {
 
     public func delete(offset: Int, length: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard offset >= 0, length >= 0, offset + length <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -140,7 +146,9 @@ extension StreamedFile {
         offset: Int,
         length: Int
     ) throws -> FileSlice {
-        guard offset >= 0, length >= 0, offset + length <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(
@@ -165,7 +173,9 @@ extension StreamedFile {
         length: Int,
         mode: StreamedFileSlice.Mode
     ) throws -> FileSlice {
-        guard offset >= 0, length >= 0, offset + length <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(
@@ -223,7 +233,9 @@ public class StreamedFileSlice: FileIOSiliceProtocol {
 
 extension StreamedFileSlice {
     public func readData(offset: Int, length: Int) throws -> Data {
-        guard offset >= 0, length >= 0, offset + length <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         switch mode {
@@ -240,7 +252,8 @@ extension StreamedFileSlice {
 
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard offset >= 0, offset + data.count <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset + data.count <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         switch mode {
@@ -277,7 +290,8 @@ extension StreamedFileSlice {
 
     public func insertData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard offset >= 0 && offset <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -291,7 +305,9 @@ extension StreamedFileSlice {
 
     public func delete(offset: Int, length: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard offset >= 0, length >= 0, offset + length <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
 


### PR DESCRIPTION
## Assemblies
<details><summary>Using `_fastPath`</summary>

```
FileIOTests`MemoryMappedFile.readData(offset:length:):
 0x10135a148 <+0>:   sub    sp, sp, #0x60
 0x10135a14c <+4>:   stp    x24, x23, [sp, #0x30]
 0x10135a150 <+8>:   stp    x22, x19, [sp, #0x40]
 0x10135a154 <+12>:  stp    x29, x30, [sp, #0x50]
 0x10135a158 <+16>:  add    x29, sp, #0x50
 0x10135a15c <+20>:  adrp   x8, 30
 0x10135a160 <+24>:  ldr    x9, [x8, #0x68]
 0x10135a164 <+28>:  add    x9, x9, #0x1
 0x10135a168 <+32>:  str    x9, [x8, #0x68]
 0x10135a16c <+36>:  tbnz   x0, #0x3f, 0x10135a1e4    ; <+156> at MemoryMappedFile.swift:92:55
 0x10135a170 <+40>:  mov    x22, x1
 0x10135a174 <+44>:  tbnz   x1, #0x3f, 0x10135a1e4    ; <+156> at MemoryMappedFile.swift:92:55
 0x10135a178 <+48>:  mov    x23, x0
 0x10135a17c <+52>:  adds   x24, x0, x22
 0x10135a180 <+56>:  b.vs   0x10135a224               ; <+220> [inlined] Swift runtime failure: arithmetic overflow at <compiler-generated>
 0x10135a184 <+60>:  mov    x19, x21
 0x10135a188 <+64>:  add    x0, x20, #0x20
 0x10135a18c <+68>:  add    x1, sp, #0x18
 0x10135a198 <+80>:  bl     0x101369a78               ; symbol stub for: swift_beginAccess
 0x10135a19c <+84>:  ldr    x8, [x20, #0x20]
 0x10135a1a0 <+88>:  cmp    x8, x24
 0x10135a1a4 <+92>:  b.lt   0x10135a1e4               ; <+156> at MemoryMappedFile.swift:92:55
 0x10135a1a8 <+96>:  add    x0, x20, #0x18
 0x10135a1ac <+100>: mov    x1, sp
 0x10135a1b8 <+112>: bl     0x101369a78               ; symbol stub for: swift_beginAccess
 0x10135a1bc <+116>: ldr    x8, [x20, #0x18]
 0x10135a1c0 <+120>: add    x0, x8, x23
 0x10135a1c4 <+124>: add    x1, x0, x22
 0x10135a1c8 <+128>: bl     0x10135dbb0               ; function signature specialization <Arg[1] = Dead> of Foundation.Data._Representation.init(Swift.UnsafeRawBufferPointer) -> Foundation.Data._Representation [inlined] generic specialization <serialized, Swift.UnsafeRawBufferPointer> of Swift.Collection.isEmpty.getter : Swift.Bool at <compiler-generated>
 0x10135a1cc <+132>: mov    x21, x19
 0x10135a1d0 <+136>: ldp    x29, x30, [sp, #0x50]
 0x10135a1d4 <+140>: ldp    x22, x19, [sp, #0x40]
 0x10135a1d8 <+144>: ldp    x24, x23, [sp, #0x30]
 0x10135a1dc <+148>: add    sp, sp, #0x60
 0x10135a1e0 <+152>: ret
 0x10135a1e4 <+156>: adrp   x8, 30
 0x10135a1e8 <+160>: ldr    x9, [x8, #0x70]
 0x10135a1ec <+164>: add    x9, x9, #0x1
 0x10135a1f0 <+168>: str    x9, [x8, #0x70]
 0x10135a1f4 <+172>: bl     0x10135e014               ; lazy protocol witness table accessor for type FileIO.FileIOError and conformance FileIO.FileIOError : Swift.Error in FileIO at <compiler-generated>
 0x10135a1f8 <+176>: mov    x1, x0
 0x10135a1fc <+180>: adrp   x0, 22
 0x10135a200 <+184>: add    x0, x0, #0x6a0            ; type metadata for FileIO.FileIOError
 0x10135a20c <+196>: bl     0x101369a60               ; symbol stub for: swift_allocError
 0x10135a210 <+200>: mov    x19, x0
 0x10135a214 <+204>: strb   wzr, [x1]
 0x10135a218 <+208>: mov    x21, x0
 0x10135a21c <+212>: bl     0x101369b2c               ; symbol stub for: swift_willThrow
 0x10135a220 <+216>: b      0x10135a1cc               ; <+132> at <compiler-generated>
 0x10135a224 <+220>: brk    #0x1
```
</details>

<details><summary>Default</summary>

```
FileIOTests`MemoryMappedFile.readData(offset:length:):
 0x10135a148 <+0>:   sub    sp, sp, #0x60
 0x10135a14c <+4>:   stp    x24, x23, [sp, #0x30]
 0x10135a150 <+8>:   stp    x22, x19, [sp, #0x40]
 0x10135a154 <+12>:  stp    x29, x30, [sp, #0x50]
 0x10135a158 <+16>:  add    x29, sp, #0x50
 0x10135a15c <+20>:  adrp   x8, 30
 0x10135a160 <+24>:  ldr    x9, [x8, #0x68]
 0x10135a164 <+28>:  add    x9, x9, #0x1
 0x10135a168 <+32>:  str    x9, [x8, #0x68]
 0x10135a16c <+36>:  tbnz   x0, #0x3f, 0x10135a1a8    ; <+96> at MemoryMappedFile.swift:92:46
 0x10135a170 <+40>:  mov    x22, x1
 0x10135a174 <+44>:  tbnz   x1, #0x3f, 0x10135a1a8    ; <+96> at MemoryMappedFile.swift:92:46
 0x10135a178 <+48>:  mov    x23, x0
 0x10135a17c <+52>:  adds   x24, x0, x22
 0x10135a180 <+56>:  b.vs   0x10135a224               ; <+220> [inlined] Swift runtime failure: arithmetic overflow at <compiler-generated>
 0x10135a184 <+60>:  mov    x19, x21
 0x10135a188 <+64>:  add    x0, x20, #0x20
 0x10135a18c <+68>:  add    x1, sp, #0x18
 0x10135a198 <+80>:  bl     0x101369a78               ; symbol stub for: swift_beginAccess
 0x10135a19c <+84>:  ldr    x8, [x20, #0x20]
 0x10135a1a0 <+88>:  cmp    x8, x24
 0x10135a1a4 <+92>:  b.ge   0x10135a1e8               ; <+160> at MemoryMappedFile.swift:95:28
 0x10135a1a8 <+96>:  adrp   x8, 30
 0x10135a1ac <+100>: ldr    x9, [x8, #0x70]
 0x10135a1b0 <+104>: add    x9, x9, #0x1
 0x10135a1b4 <+108>: str    x9, [x8, #0x70]
 0x10135a1b8 <+112>: bl     0x10135e014               ; lazy protocol witness table accessor for type FileIO.FileIOError and conformance FileIO.FileIOError : Swift.Error in FileIO at <compiler-generated>
 0x10135a1bc <+116>: mov    x1, x0
 0x10135a1c0 <+120>: adrp   x0, 22
 0x10135a1c4 <+124>: add    x0, x0, #0x6a0            ; type metadata for FileIO.FileIOError
 0x10135a1d0 <+136>: bl     0x101369a60               ; symbol stub for: swift_allocError
 0x10135a1d4 <+140>: mov    x19, x0
 0x10135a1d8 <+144>: strb   wzr, [x1]
 0x10135a1dc <+148>: mov    x21, x0
 0x10135a1e0 <+152>: bl     0x101369b2c               ; symbol stub for: swift_willThrow
 0x10135a1e4 <+156>: b      0x10135a20c               ; <+196> at <compiler-generated>
 0x10135a1e8 <+160>: add    x0, x20, #0x18
 0x10135a1ec <+164>: mov    x1, sp
 0x10135a1f8 <+176>: bl     0x101369a78               ; symbol stub for: swift_beginAccess
 0x10135a1fc <+180>: ldr    x8, [x20, #0x18]
 0x10135a200 <+184>: add    x0, x8, x23
 0x10135a204 <+188>: add    x1, x0, x22
 0x10135a208 <+192>: bl     0x10135dbb0               ; function signature specialization <Arg[1] = Dead> of Foundation.Data._Representation.init(Swift.UnsafeRawBufferPointer) -> Foundation.Data._Representation [inlined] generic specialization <serialized, Swift.UnsafeRawBufferPointer> of Swift.Collection.isEmpty.getter : Swift.Bool at <compiler-generated>
 0x10135a20c <+196>: mov    x21, x19
 0x10135a210 <+200>: ldp    x29, x30, [sp, #0x50]
 0x10135a214 <+204>: ldp    x22, x19, [sp, #0x40]
 0x10135a218 <+208>: ldp    x24, x23, [sp, #0x30]
 0x10135a21c <+212>: add    sp, sp, #0x60
 0x10135a220 <+216>: ret
 0x10135a224 <+220>: brk    #0x1
```
</details>