### PR TITLE
Support virtual concatenation of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ A Swift library for reading and writing files.
 - [MemoryMappedFile](./Sources/FileIO/MemoryMappedFile.swift): using mmap
 - [StreamedFile](./Sources/FileIO/StreamedFile.swift): using FileHandle (syscall)
 
+- [ConcatenatedMemoryMappedFile](./Sources/FileIO/ConcatenatedMemoryMappedFile.swift): using mmap. Treats multiple files as one continuous virtual file.
+- [StreamedFile](./Sources/FileIO/ConcatenatedStreamedFile.swift): using FileHandle (syscall). Treats multiple files as one continuous virtual file.
+
 ## Usage
 
 MemoryMappedFile/StreamedFile have the same API available for both.

--- a/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
+++ b/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
@@ -1,0 +1,203 @@
+//
+//  ConcatenatedMemoryMappedFile.swift
+//  swift-fileio
+//
+//  Created by p-x9 on 2025/07/12
+//  
+//
+
+import Foundation
+
+public final class ConcatenatedMemoryMappedFile: MemoryMappedFileIOProtocol {
+    public private(set) var ptr: UnsafeMutableRawPointer
+    public private(set) var size: Int
+
+    public let isWritable: Bool
+
+    public let _files: [MemoryMappedFile]
+
+    private init(
+        ptr: UnsafeMutableRawPointer,
+        size: Int,
+        isWritable: Bool,
+        files: [MemoryMappedFile]
+    ) {
+        self.ptr = ptr
+        self.size = size
+        self.isWritable = isWritable
+        self._files = files
+    }
+}
+
+extension ConcatenatedMemoryMappedFile {
+    public static func open(url: URL, isWritable: Bool) throws -> ConcatenatedMemoryMappedFile {
+        try open(urls: [url], isWritable: isWritable)
+    }
+
+    public static func open(
+        urls: [URL],
+        isWritable: Bool
+    ) throws -> ConcatenatedMemoryMappedFile {
+        var fdAndSizes: [(fd: CInt, size: off_t)] = []
+        for url in urls {
+            let fd = _open(url.path, isWritable ? O_RDWR : O_RDONLY)
+            guard _fastPath(fd > 0) else {
+                cleanup(fds: fdAndSizes.map(\.fd))
+                throw POSIXError(.init(rawValue: errno)!)
+            }
+
+            let fileSize = lseek(fd, 0, SEEK_END)
+            guard _fastPath(fileSize > 0) else {
+                cleanup(fds: fdAndSizes.map(\.fd))
+                close(fd)
+                throw POSIXError(.init(rawValue: errno)!)
+            }
+
+            fdAndSizes.append((fd, fileSize))
+        }
+
+        let fullSize = fdAndSizes.reduce(0, { $0 + $1.size })
+
+        let basePtr = mmap(
+            nil,
+            numericCast(fullSize),
+            PROT_NONE,
+            MAP_PRIVATE | MAP_ANONYMOUS,
+            -1,
+            0
+        )
+        guard let basePtr,
+              _fastPath(basePtr != MAP_FAILED) else {
+            cleanup(fds: fdAndSizes.map(\.fd))
+            throw POSIXError(.init(rawValue: errno)!)
+        }
+
+        var prot: Int32 = PROT_READ
+        if isWritable { prot |= PROT_WRITE }
+
+        var offset = 0
+        var files: [MemoryMappedFile] = []
+        for (fd, size) in fdAndSizes {
+            let size: Int = numericCast(size)
+            let ptr = basePtr.advanced(by: offset)
+            let mappedPtr = mmap(ptr, size, prot, MAP_FIXED | MAP_PRIVATE, fd, 0)
+            guard ptr == mappedPtr,
+                  _fastPath(ptr != MAP_FAILED) else {
+                cleanup(fds: fdAndSizes.map(\.fd))
+                throw POSIXError(.init(rawValue: errno)!)
+            }
+            files.append(
+                .init(
+                    fileDescriptor: fd,
+                    ptr: ptr,
+                    size: size,
+                    isWritable: isWritable
+                )
+            )
+            offset += size
+        }
+
+        return .init(
+            ptr: basePtr,
+            size: numericCast(fullSize),
+            isWritable: isWritable,
+            files: files
+        )
+    }
+
+    private static func cleanup(fds: [CInt]) {
+        fds.forEach { close($0) }
+    }
+}
+
+extension ConcatenatedMemoryMappedFile {
+    @inlinable @inline(__always)
+    public func readData(offset: Int, length: Int) throws -> Data {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        return Data(bytes: ptr.advanced(by: offset), count: length)
+    }
+
+    @inlinable @inline(__always)
+    public func writeData(_ data: Data, at offset: Int) throws {
+        guard isWritable else { throw FileIOError.notWritable }
+        guard _fastPath(offset >= 0),
+              _fastPath(offset + data.count <= size) else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        data.withUnsafeBytes { buffer in
+            memcpy(ptr.advanced(by: offset), buffer.baseAddress!, data.count)
+            msync(ptr.advanced(by: offset), data.count, MS_SYNC)
+        }
+    }
+
+    @inlinable @inline(__always)
+    public func sync() {
+        _files.forEach { $0.sync() }
+    }
+
+    internal func unmap() {
+        _files.forEach { $0.unmap() }
+    }
+}
+
+extension ConcatenatedMemoryMappedFile {
+    @_disfavoredOverload
+    @inlinable @inline(__always)
+    public func read<T>(offset: Int) throws -> T {
+        try read(offset: offset, as: T.self)
+    }
+
+    @inlinable @inline(__always)
+    public func read<T>(offset: Int) throws -> Optional<T> {
+        try read(offset: offset, as: T.self)
+    }
+
+    @inlinable @inline(__always)
+    public func read<T>(offset: Int, as: T.Type) throws -> T {
+        let length = MemoryLayout<T>.size
+        guard _fastPath(offset + length <= size) else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        return ptr.advanced(by: offset)
+            .assumingMemoryBound(to: T.self)
+            .pointee
+    }
+
+    @inlinable @inline(__always)
+    public func write<T>(_ value: T, at offset: Int) throws {
+        guard isWritable else { throw FileIOError.notWritable }
+        let length = MemoryLayout<T>.size
+        guard _fastPath(offset + length <= size) else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        ptr.advanced(by: offset)
+            .assumingMemoryBound(to: T.self)
+            .pointee = value
+        msync(ptr.advanced(by: offset), length, MS_SYNC)
+    }
+}
+
+extension ConcatenatedMemoryMappedFile {
+    public typealias FileSlice = MemoryMappedFileSlice<ConcatenatedMemoryMappedFile>
+
+    public func fileSlice(
+        offset: Int,
+        length: Int
+    ) throws -> FileSlice {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        return .init(
+            parent: self,
+            baseOffset: offset,
+            size: length,
+            isWritable: isWritable
+        )
+    }
+}

--- a/Sources/FileIO/ConcatenatedStreamedFile.swift
+++ b/Sources/FileIO/ConcatenatedStreamedFile.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public final class ConcatenatedStreamedFile: StreamedFileIOProtocol {
-    public struct File {
+    public struct FileSegment {
         public let offset: Int
         public let size: Int
         public let _file: StreamedFile
@@ -18,12 +18,12 @@ public final class ConcatenatedStreamedFile: StreamedFileIOProtocol {
     public let size: Int
     public let isWritable: Bool
 
-    public let _files: [File]
+    public let _files: [FileSegment]
 
     private init(
         size: Int,
         isWritable: Bool,
-        files: [File]
+        files: [FileSegment]
     ) {
         self.size = size
         self.isWritable = isWritable
@@ -40,7 +40,7 @@ extension ConcatenatedStreamedFile {
         urls: [URL],
         isWritable: Bool
     ) throws -> ConcatenatedStreamedFile {
-        var files: [File] = []
+        var files: [FileSegment] = []
         var fullSize: Int = 0
         for url in urls {
             let file: StreamedFile = try .open(url: url, isWritable: isWritable)
@@ -57,7 +57,7 @@ extension ConcatenatedStreamedFile {
 
 extension ConcatenatedStreamedFile {
     @inlinable @inline(__always)
-    public func _file(for offset: Int) throws -> File {
+    public func _file(for offset: Int) throws -> FileSegment {
         guard let file = _files.first(
             where: { $0.offset <= offset && offset < $0.offset + $0.size }
         ) else {

--- a/Sources/FileIO/ConcatenatedStreamedFile.swift
+++ b/Sources/FileIO/ConcatenatedStreamedFile.swift
@@ -67,6 +67,7 @@ extension ConcatenatedStreamedFile {
     }
 }
 
+// Must support reading and writing of boundaries between files.
 extension ConcatenatedStreamedFile {
     @inlinable @inline(__always)
     public func readData(offset: Int, length: Int) throws -> Data {

--- a/Sources/FileIO/ConcatenatedStreamedFile.swift
+++ b/Sources/FileIO/ConcatenatedStreamedFile.swift
@@ -1,0 +1,203 @@
+//
+//  ConcatenatedStreamedFile.swift
+//  swift-fileio
+//
+//  Created by p-x9 on 2025/07/13
+//  
+//
+
+import Foundation
+
+public final class ConcatenatedStreamedFile: StreamedFileIOProtocol {
+    public struct File {
+        public let offset: Int
+        public let size: Int
+        public let _file: StreamedFile
+    }
+
+    public let size: Int
+    public let isWritable: Bool
+
+    public let _files: [File]
+
+    private init(
+        size: Int,
+        isWritable: Bool,
+        files: [File]
+    ) {
+        self.size = size
+        self.isWritable = isWritable
+        self._files = files
+    }
+}
+
+extension ConcatenatedStreamedFile {
+    public static func open(url: URL, isWritable: Bool) throws -> ConcatenatedStreamedFile {
+        try open(urls: [url], isWritable: isWritable)
+    }
+
+    public static func open(
+        urls: [URL],
+        isWritable: Bool
+    ) throws -> ConcatenatedStreamedFile {
+        var files: [File] = []
+        var fullSize: Int = 0
+        for url in urls {
+            let file: StreamedFile = try .open(url: url, isWritable: isWritable)
+            files.append(.init(offset: fullSize, size: file.size, _file: file))
+            fullSize += file.size
+        }
+        return .init(
+            size: fullSize,
+            isWritable: isWritable,
+            files: files
+        )
+    }
+}
+
+extension ConcatenatedStreamedFile {
+    @inlinable @inline(__always)
+    public func _file(for offset: Int) throws -> File {
+        guard let file = _files.first(
+            where: { $0.offset <= offset && offset < $0.offset + $0.size }
+        ) else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        return file
+    }
+}
+
+extension ConcatenatedStreamedFile {
+    @inlinable @inline(__always)
+    public func readData(offset: Int, length: Int) throws -> Data {
+        guard offset >= 0, length >= 0, offset + length <= size else {
+            throw FileIOError.offsetOutOfBounds
+        }
+
+        var remaining = length
+        var currentOffset = offset
+        var result = Data()
+
+        while remaining > 0 {
+            let file = try _file(for: currentOffset)
+            let localOffset = currentOffset - file.offset
+            let readable = min(remaining, file.size - localOffset)
+
+            let chunk = try file._file.readData(offset: localOffset, length: readable)
+            result.append(chunk)
+
+            currentOffset += readable
+            remaining -= readable
+        }
+        return result
+    }
+
+    @inlinable @inline(__always)
+    public func writeData(_ data: Data, at offset: Int) throws {
+        guard isWritable else { throw FileIOError.notWritable }
+        guard offset >= 0, offset + data.count <= size else {
+            throw FileIOError.offsetOutOfBounds
+        }
+
+        var remaining = data.count
+        var currentOffset = offset
+        var written = 0
+
+        while remaining > 0 {
+            let file = try _file(for: currentOffset)
+            let localOffset = currentOffset - file.offset
+            let writable = min(remaining, file.size - localOffset)
+
+            let slice = data.subdata(in: written ..< written + writable)
+            try file._file.writeData(slice, at: localOffset)
+
+            written += writable
+            currentOffset += writable
+            remaining -= writable
+        }
+    }
+
+    @inlinable @inline(__always)
+    public func sync() {
+        _files.forEach { $0._file.sync() }
+    }
+}
+
+extension ConcatenatedStreamedFile {
+    @_disfavoredOverload
+    @inlinable @inline(__always)
+    public func read<T>(offset: Int) throws -> T {
+        try read(offset: offset, as: T.self)
+    }
+
+    @inlinable @inline(__always)
+    public func read<T>(offset: Int) throws -> Optional<T> {
+        try read(offset: offset, as: T.self)
+    }
+
+    @inlinable @inline(__always)
+    public func read<T>(offset: Int, as: T.Type) throws -> T {
+        let length = MemoryLayout<T>.size
+        let data = try readData(offset: offset, length: length)
+        return data.withUnsafeBytes {
+            $0.load(as: T.self)
+        }
+    }
+
+    @inlinable @inline(__always)
+    public func write<T>(_ value: T, at offset: Int) throws {
+        let data = withUnsafeBytes(of: value, {
+            Data(buffer: $0.assumingMemoryBound(to: UInt8.self))
+        })
+        try self.writeData(data, at: offset)
+    }
+}
+
+extension ConcatenatedStreamedFile {
+    public typealias FileSlice = StreamedFileSlice<ConcatenatedStreamedFile>
+
+    public func fileSlice(
+        offset: Int,
+        length: Int
+    ) throws -> FileSlice {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        return try .init(
+            parent: self,
+            baseOffset: offset,
+            size: length,
+            isWritable: isWritable,
+            mode: .buffered
+        )
+    }
+
+    /// Creates a `FileSlice` representing a portion of the file.
+    ///
+    /// - Parameters:
+    ///   - offset: The starting position of the slice within the file.
+    ///   - length: The size of the slice in bytes.
+    ///   - mode: The mode of operation for the slice (`.direct` or `.buffered`).
+    /// - Returns: A `FileSlice` that provides access to the specified portion of the file.
+    /// - Throws: `FileIOError.offsetOutOfBounds` if the specified range is invalid.
+    public func fileSlice(
+        offset: Int,
+        length: Int,
+        mode: FileSlice.Mode
+    ) throws -> FileSlice {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        return try .init(
+            parent: self,
+            baseOffset: offset,
+            size: length,
+            isWritable: isWritable,
+            mode: mode
+        )
+    }
+}

--- a/Sources/FileIO/FileIO.swift
+++ b/Sources/FileIO/FileIO.swift
@@ -90,6 +90,8 @@ public protocol MemoryMappedFileIOProtocol: FileIOProtocol {
     var ptr: UnsafeMutableRawPointer { get }
 }
 
+public protocol StreamedFileIOProtocol: FileIOProtocol {}
+
 extension _FileIOProtocol {
     /// Reads up to a specified number of bytes from the file, starting at a given offset.
     ///

--- a/Sources/FileIO/FileIO.swift
+++ b/Sources/FileIO/FileIO.swift
@@ -33,6 +33,38 @@ public protocol _FileIOProtocol {
     /// Ensures that any pending data modifications are written to the file.
     func sync()
 
+    func read<T>(offset: Int) throws -> T
+    func read<T>(offset: Int, as: T.Type) throws -> T
+    func write<T>(_ value: T, at offset: Int) throws
+}
+
+public protocol FileIOProtocol: _FileIOProtocol {
+    associatedtype FileSlice: FileIOSiliceProtocol
+
+    /// Opens a file at the specified URL.
+    ///
+    /// - Parameters:
+    ///   - url: The file URL to open.
+    ///   - isWritable: A boolean indicating whether the file should be opened for writing.
+    /// - Returns: An instance of `Self` for file operations.
+    /// - Throws: An error if the file cannot be opened.
+    static func open(url: URL, isWritable: Bool) throws -> Self
+
+    /// Creates a `FileSlice` representing a portion of the file.
+    ///
+    /// - Parameters:
+    ///   - offset: The starting position of the slice within the file.
+    ///   - length: The size of the slice in bytes.
+    /// - Returns: A `FileSlice` that provides access to the specified portion of the file.
+    /// - Throws: `FileIOError.offsetOutOfBounds` if the specified range is invalid.
+    func fileSlice(offset: Int, length: Int) throws -> FileSlice
+}
+
+public protocol FileIOSiliceProtocol: _FileIOProtocol {
+    var baseOffset: Int { get }
+}
+
+public protocol ResizableFileIOProtocol: _FileIOProtocol {
     /// Inserts data into the file at the specified offset, shifting existing data.
     ///
     /// - Parameters:
@@ -52,42 +84,10 @@ public protocol _FileIOProtocol {
     ///   - `FileIOError.notWritable` if the file is not writable.
     ///   - `FileIOError.offsetOutOfBounds` if the specified range is invalid.
     func delete(offset: Int, length: Int) throws
-
-    func read<T>(offset: Int) throws -> T
-    func read<T>(offset: Int, as: T.Type) throws -> T
-    func write<T>(_ value: T, at offset: Int) throws
 }
 
-public protocol FileIOProtocol: _FileIOProtocol {
-    associatedtype FileSlice: FileIOSiliceProtocol
-
-    /// Opens a file at the specified URL.
-    ///
-    /// - Parameters:
-    ///   - url: The file URL to open.
-    ///   - isWritable: A boolean indicating whether the file should be opened for writing.
-    /// - Returns: An instance of `Self` for file operations.
-    /// - Throws: An error if the file cannot be opened.
-    static func open(url: URL, isWritable: Bool) throws -> Self
-
-    /// Resizes the file to the specified new size.
-    ///
-    /// - Parameter newSize: The new size of the file in bytes.
-    /// - Throws: `FileIOError.notWritable` if the file is not writable.
-    func resize(newSize: Int) throws
-
-    /// Creates a `FileSlice` representing a portion of the file.
-    ///
-    /// - Parameters:
-    ///   - offset: The starting position of the slice within the file.
-    ///   - length: The size of the slice in bytes.
-    /// - Returns: A `FileSlice` that provides access to the specified portion of the file.
-    /// - Throws: `FileIOError.offsetOutOfBounds` if the specified range is invalid.
-    func fileSlice(offset: Int, length: Int) throws -> FileSlice
-}
-
-public protocol FileIOSiliceProtocol: _FileIOProtocol {
-    var baseOffset: Int { get }
+public protocol MemoryMappedFileIOProtocol: FileIOProtocol {
+    var ptr: UnsafeMutableRawPointer { get }
 }
 
 extension _FileIOProtocol {

--- a/Sources/FileIO/StreamedFile.swift
+++ b/Sources/FileIO/StreamedFile.swift
@@ -72,7 +72,7 @@ extension StreamedFile {
     }
 }
 
-extension StreamedFile {
+extension StreamedFile: ResizableFileIOProtocol {
     public func resize(newSize: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         guard _fastPath(newSize > 0) else { return }
@@ -287,7 +287,9 @@ extension StreamedFileSlice {
         guard let buffer else { return }
         self.buffer = buffer
     }
+}
 
+extension StreamedFileSlice: ResizableFileIOProtocol {
     public func insertData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         guard _fastPath(offset >= 0),
@@ -318,7 +320,9 @@ extension StreamedFileSlice {
             buffer?.removeSubrange(offset ..< offset + length)
         }
     }
+}
 
+extension StreamedFileSlice {
     @_disfavoredOverload
     @inlinable @inline(__always)
     public func read<T>(offset: Int) throws -> T {

--- a/Sources/FileIO/system.swift
+++ b/Sources/FileIO/system.swift
@@ -1,0 +1,27 @@
+//
+//  system.swift
+//  swift-fileio
+//
+//  Created by p-x9 on 2025/07/12
+//  
+//
+
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+package let _open = Darwin.open(_:_:)
+#elseif canImport(Glibc)
+import Glibc
+package let _open = Glibc.open(_:_:)
+#elseif canImport(Musl)
+import Musl
+package let _open = Musl.open(_:_:)
+#elseif canImport(WASILibc)
+import WASILibc
+package let _open = WASILibc.open(_:_:)
+#elseif canImport(Android)
+import Android
+package let _open = Android.open(_:_:)
+#endif
+


### PR DESCRIPTION
## Summary

This PR introduces two new types: `ConcatenatedStreamedFile` and `ConcatenatedMemoryMappedFile`.

These types allow multiple physical files to be treated as a single logical file by virtually concatenating them. This enables seamless read/write operations across file boundaries without requiring the files to be physically merged.

## Changes

- **ConcatenatedStreamedFile**
  - Handles file I/O using `StreamedFile`
  - Supports reading and writing data across multiple underlying files
  - Provides `fileSlice` support for sliced views

- **ConcatenatedMemoryMappedFile**
  - Handles file I/O using memory mapping
  - Maps multiple files into contiguous virtual memory using `mmap` with `MAP_FIXED`
  - Enables high-performance read/write access across concatenated memory-mapped regions

- Introduced internal `FileSegment` struct to manage offset, size, and file metadata within the concatenated range

## Use Cases

- Large file emulation by stitching smaller files together
- Segmented file storage where each segment is stored independently
- Efficient random access across multiple files as a single addressable space

## Notes

- Both types conform to their respective I/O protocols (`StreamedFileIOProtocol`, `MemoryMappedFileIOProtocol`)
- Proper error handling is in place to ensure offset bounds checking
- `ConcatenatedMemoryMappedFile` ensures all files are mapped contiguously, and will fail if mapping cannot be completed