### PR TITLE
Add  `readAllData` method for reading entire file contents

### DIFF
--- a/Sources/FileIO/FileIO.swift
+++ b/Sources/FileIO/FileIO.swift
@@ -110,4 +110,14 @@ extension _FileIOProtocol {
         let size = min(count, size - offset)
         return try readData(offset: offset, length: size)
     }
+
+    /// Reads the entire contents of the file.
+    ///
+    /// - Returns: A `Data` object containing all bytes in the file, from offset `0`
+    ///   up to the current file size.
+    /// - Throws: `FileIOError.offsetOutOfBounds` if the file size is invalid or
+    ///   cannot be read.
+    public func readAllData() throws -> Data {
+        try readData(offset: 0, length: size)
+    }
 }


### PR DESCRIPTION
- Implements a new method to read all bytes from the file starting at offset 0
- Throws FileIOError.offsetOutOfBounds for invalid file sizes