### PR TITLE
Add benchmark module using ordo-one/benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+Benchmarks/.benchmarkBaselines/
+Benchmarks/.build/
+Benchmarks/.swiftpm/
+Benchmarks/Package.resolved

--- a/Benchmarks/Benchmarks/FileIOBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/FileIOBenchmarks/Benchmarks.swift
@@ -1,0 +1,8 @@
+import Benchmark
+
+let benchmarks: @Sendable () -> Void = {
+    registerMemoryMappedFileBenchmarks()
+    registerStreamedFileBenchmarks()
+    registerConcatenatedMemoryMappedFileBenchmarks()
+    registerConcatenatedStreamedFileBenchmarks()
+}

--- a/Benchmarks/Benchmarks/FileIOBenchmarks/ConcatenatedMemoryMappedFileBenchmarks.swift
+++ b/Benchmarks/Benchmarks/FileIOBenchmarks/ConcatenatedMemoryMappedFileBenchmarks.swift
@@ -1,0 +1,92 @@
+import Benchmark
+import Foundation
+import FileIO
+
+func registerConcatenatedMemoryMappedFileBenchmarks() {
+    Benchmark("ConcatenatedMemoryMappedFile.open") { benchmark in
+        let fixture = BenchmarkFixtures.makeConcatenatedFixture(
+            count: 4,
+            size: BenchmarkFixtures.defaultSegmentSize
+        )
+        defer { BenchmarkFixtures.cleanup(fixture.directory) }
+
+        benchmark.startMeasurement()
+
+        for _ in benchmark.scaledIterations {
+            let file = try ConcatenatedMemoryMappedFile.open(
+                urls: fixture.urls,
+                isWritable: false
+            )
+            blackHole(file)
+        }
+    }
+
+    Benchmark("ConcatenatedMemoryMappedFile.readData") { benchmark in
+        let fixture = BenchmarkFixtures.makeConcatenatedFixture(
+            count: 4,
+            size: BenchmarkFixtures.defaultSegmentSize
+        )
+        defer { BenchmarkFixtures.cleanup(fixture.directory) }
+        let file = try ConcatenatedMemoryMappedFile.open(
+            urls: fixture.urls,
+            isWritable: false
+        )
+        let ranges = BenchmarkFixtures.readRanges(
+            size: file.size,
+            length: 4 * 1024,
+            count: 1_000
+        )
+
+        benchmark.startMeasurement()
+
+        for range in ranges {
+            blackHole(try file.readData(offset: range.offset, length: range.length))
+        }
+    }
+
+    Benchmark("ConcatenatedMemoryMappedFile.read.UInt64") { benchmark in
+        let fixture = BenchmarkFixtures.makeConcatenatedFixture(
+            count: 4,
+            size: BenchmarkFixtures.defaultSegmentSize
+        )
+        defer { BenchmarkFixtures.cleanup(fixture.directory) }
+        let file = try ConcatenatedMemoryMappedFile.open(
+            urls: fixture.urls,
+            isWritable: false
+        )
+        let offsets = BenchmarkFixtures.typedOffsets(
+            size: file.size,
+            as: UInt64.self,
+            count: 100_000
+        )
+
+        benchmark.startMeasurement()
+
+        for offset in offsets {
+            blackHole(try file.read(offset: offset, as: UInt64.self))
+        }
+    }
+
+    Benchmark("ConcatenatedMemoryMappedFile._file.lookup") { benchmark in
+        let fixture = BenchmarkFixtures.makeConcatenatedFixture(
+            count: 8,
+            size: BenchmarkFixtures.defaultSegmentSize
+        )
+        defer { BenchmarkFixtures.cleanup(fixture.directory) }
+        let file = try ConcatenatedMemoryMappedFile.open(
+            urls: fixture.urls,
+            isWritable: false
+        )
+        let offsets = BenchmarkFixtures.typedOffsets(
+            size: file.size,
+            as: UInt8.self,
+            count: 10_000
+        )
+
+        benchmark.startMeasurement()
+
+        for offset in offsets {
+            blackHole(try file._file(for: offset))
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/FileIOBenchmarks/ConcatenatedStreamedFileBenchmarks.swift
+++ b/Benchmarks/Benchmarks/FileIOBenchmarks/ConcatenatedStreamedFileBenchmarks.swift
@@ -1,0 +1,69 @@
+import Benchmark
+import Foundation
+import FileIO
+
+func registerConcatenatedStreamedFileBenchmarks() {
+    Benchmark("ConcatenatedStreamedFile.open") { benchmark in
+        let fixture = BenchmarkFixtures.makeConcatenatedFixture(
+            count: 4,
+            size: BenchmarkFixtures.defaultSegmentSize
+        )
+        defer { BenchmarkFixtures.cleanup(fixture.directory) }
+
+        benchmark.startMeasurement()
+
+        for _ in benchmark.scaledIterations {
+            let file = try ConcatenatedStreamedFile.open(
+                urls: fixture.urls,
+                isWritable: false
+            )
+            blackHole(file)
+        }
+    }
+
+    Benchmark("ConcatenatedStreamedFile.readData") { benchmark in
+        let fixture = BenchmarkFixtures.makeConcatenatedFixture(
+            count: 4,
+            size: BenchmarkFixtures.defaultSegmentSize
+        )
+        defer { BenchmarkFixtures.cleanup(fixture.directory) }
+        let file = try ConcatenatedStreamedFile.open(
+            urls: fixture.urls,
+            isWritable: false
+        )
+        let ranges = BenchmarkFixtures.readRanges(
+            size: file.size,
+            length: 4 * 1024,
+            count: 1_000
+        )
+
+        benchmark.startMeasurement()
+
+        for range in ranges {
+            blackHole(try file.readData(offset: range.offset, length: range.length))
+        }
+    }
+
+    Benchmark("ConcatenatedStreamedFile.read.UInt64") { benchmark in
+        let fixture = BenchmarkFixtures.makeConcatenatedFixture(
+            count: 4,
+            size: BenchmarkFixtures.defaultSegmentSize
+        )
+        defer { BenchmarkFixtures.cleanup(fixture.directory) }
+        let file = try ConcatenatedStreamedFile.open(
+            urls: fixture.urls,
+            isWritable: false
+        )
+        let offsets = BenchmarkFixtures.typedOffsets(
+            size: file.size,
+            as: UInt64.self,
+            count: 10_000
+        )
+
+        benchmark.startMeasurement()
+
+        for offset in offsets {
+            blackHole(try file.read(offset: offset, as: UInt64.self))
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/FileIOBenchmarks/Fixtures.swift
+++ b/Benchmarks/Benchmarks/FileIOBenchmarks/Fixtures.swift
@@ -1,0 +1,107 @@
+import Benchmark
+import Foundation
+import FileIO
+
+enum BenchmarkFixtures {
+    /// Default fixture size in bytes (8 MiB; multiple of 16 KiB page size).
+    static let defaultFileSize: Int = 8 * 1024 * 1024
+
+    /// Default segment size for concatenated fixtures (2 MiB; multiple of 16 KiB page size).
+    static let defaultSegmentSize: Int = 2 * 1024 * 1024
+
+    /// Returns a unique temporary directory rooted under `NSTemporaryDirectory()`.
+    static func makeTempDirectory() -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("swift-fileio-benchmarks", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    static func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    /// Creates a fixture file on disk filled with a deterministic pattern.
+    static func makeFile(
+        at url: URL,
+        size: Int
+    ) {
+        let manager = FileManager.default
+        try? manager.removeItem(at: url)
+        manager.createFile(atPath: url.path, contents: nil)
+        guard let handle = try? FileHandle(forWritingTo: url) else {
+            fatalError("Failed to create fixture file at \(url.path)")
+        }
+        defer { try? handle.close() }
+
+        let chunkSize = 64 * 1024
+        var chunk = Data(count: chunkSize)
+        chunk.withUnsafeMutableBytes { buffer in
+            guard let base = buffer.baseAddress else { return }
+            for i in 0..<chunkSize {
+                base.advanced(by: i).storeBytes(of: UInt8(i & 0xff), as: UInt8.self)
+            }
+        }
+
+        var written = 0
+        while written < size {
+            let remaining = size - written
+            if remaining >= chunkSize {
+                handle.write(chunk)
+                written += chunkSize
+            } else {
+                handle.write(chunk.prefix(remaining))
+                written += remaining
+            }
+        }
+    }
+
+    /// Creates `count` fixture files of identical `size` in a fresh temp directory.
+    /// Returns the directory and the URLs of the created files.
+    static func makeConcatenatedFixture(
+        count: Int,
+        size: Int
+    ) -> (directory: URL, urls: [URL]) {
+        let dir = makeTempDirectory()
+        var urls: [URL] = []
+        urls.reserveCapacity(count)
+        for i in 0..<count {
+            let url = dir.appendingPathComponent("segment_\(i).bin")
+            makeFile(at: url, size: size)
+            urls.append(url)
+        }
+        return (dir, urls)
+    }
+
+    /// Returns a deterministic list of `(offset, length)` pairs that fit within `size`.
+    static func readRanges(
+        size: Int,
+        length: Int,
+        count: Int
+    ) -> [(offset: Int, length: Int)] {
+        guard size > length, count > 0 else { return [] }
+        let span = size - length
+        let stride = max(span / count, 1)
+        return (0..<count).map { i in
+            (offset: (i * stride) % span, length: length)
+        }
+    }
+
+    /// Returns a deterministic list of offsets aligned for `T`-sized reads within `size`.
+    static func typedOffsets<T>(
+        size: Int,
+        as type: T.Type,
+        count: Int
+    ) -> [Int] {
+        let length = MemoryLayout<T>.size
+        guard size > length, count > 0 else { return [] }
+        let span = size - length
+        let alignment = max(MemoryLayout<T>.alignment, 1)
+        let stride = max(span / count, alignment)
+        return (0..<count).map { i in
+            let raw = (i * stride) % span
+            return raw - (raw % alignment)
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/FileIOBenchmarks/MemoryMappedFileBenchmarks.swift
+++ b/Benchmarks/Benchmarks/FileIOBenchmarks/MemoryMappedFileBenchmarks.swift
@@ -1,0 +1,92 @@
+import Benchmark
+import Foundation
+import FileIO
+
+func registerMemoryMappedFileBenchmarks() {
+    Benchmark("MemoryMappedFile.open") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+
+        benchmark.startMeasurement()
+
+        for _ in benchmark.scaledIterations {
+            let file = try MemoryMappedFile.open(url: url, isWritable: false)
+            blackHole(file)
+        }
+    }
+
+    Benchmark("MemoryMappedFile.readData") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+        let file = try MemoryMappedFile.open(url: url, isWritable: false)
+        let ranges = BenchmarkFixtures.readRanges(
+            size: file.size,
+            length: 4 * 1024,
+            count: 1_000
+        )
+
+        benchmark.startMeasurement()
+
+        for range in ranges {
+            blackHole(try file.readData(offset: range.offset, length: range.length))
+        }
+    }
+
+    Benchmark("MemoryMappedFile.read.UInt64") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+        let file = try MemoryMappedFile.open(url: url, isWritable: false)
+        let offsets = BenchmarkFixtures.typedOffsets(
+            size: file.size,
+            as: UInt64.self,
+            count: 100_000
+        )
+
+        benchmark.startMeasurement()
+
+        for offset in offsets {
+            blackHole(try file.read(offset: offset, as: UInt64.self))
+        }
+    }
+
+    Benchmark("MemoryMappedFile.readAllData") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+        let file = try MemoryMappedFile.open(url: url, isWritable: false)
+
+        benchmark.startMeasurement()
+
+        for _ in benchmark.scaledIterations {
+            blackHole(try file.readAllData())
+        }
+    }
+
+    Benchmark("MemoryMappedFile.fileSlice.readData") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+        let file = try MemoryMappedFile.open(url: url, isWritable: false)
+        let sliceLength = file.size / 2
+        let slice = try file.fileSlice(offset: file.size / 4, length: sliceLength)
+        let ranges = BenchmarkFixtures.readRanges(
+            size: sliceLength,
+            length: 4 * 1024,
+            count: 1_000
+        )
+
+        benchmark.startMeasurement()
+
+        for range in ranges {
+            blackHole(try slice.readData(offset: range.offset, length: range.length))
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/FileIOBenchmarks/StreamedFileBenchmarks.swift
+++ b/Benchmarks/Benchmarks/FileIOBenchmarks/StreamedFileBenchmarks.swift
@@ -1,0 +1,121 @@
+import Benchmark
+import Foundation
+import FileIO
+
+func registerStreamedFileBenchmarks() {
+    Benchmark("StreamedFile.open") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+
+        benchmark.startMeasurement()
+
+        for _ in benchmark.scaledIterations {
+            let file = try StreamedFile.open(url: url, isWritable: false)
+            blackHole(file)
+        }
+    }
+
+    Benchmark("StreamedFile.readData") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+        let file = try StreamedFile.open(url: url, isWritable: false)
+        let ranges = BenchmarkFixtures.readRanges(
+            size: file.size,
+            length: 4 * 1024,
+            count: 1_000
+        )
+
+        benchmark.startMeasurement()
+
+        for range in ranges {
+            blackHole(try file.readData(offset: range.offset, length: range.length))
+        }
+    }
+
+    Benchmark("StreamedFile.read.UInt64") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+        let file = try StreamedFile.open(url: url, isWritable: false)
+        let offsets = BenchmarkFixtures.typedOffsets(
+            size: file.size,
+            as: UInt64.self,
+            count: 10_000
+        )
+
+        benchmark.startMeasurement()
+
+        for offset in offsets {
+            blackHole(try file.read(offset: offset, as: UInt64.self))
+        }
+    }
+
+    Benchmark("StreamedFile.readAllData") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+        let file = try StreamedFile.open(url: url, isWritable: false)
+
+        benchmark.startMeasurement()
+
+        for _ in benchmark.scaledIterations {
+            blackHole(try file.readAllData())
+        }
+    }
+
+    Benchmark("StreamedFile.fileSlice.buffered.readData") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+        let file = try StreamedFile.open(url: url, isWritable: false)
+        let sliceLength = file.size / 2
+        let slice = try file.fileSlice(
+            offset: file.size / 4,
+            length: sliceLength,
+            mode: .buffered
+        )
+        let ranges = BenchmarkFixtures.readRanges(
+            size: sliceLength,
+            length: 4 * 1024,
+            count: 1_000
+        )
+
+        benchmark.startMeasurement()
+
+        for range in ranges {
+            blackHole(try slice.readData(offset: range.offset, length: range.length))
+        }
+    }
+
+    Benchmark("StreamedFile.fileSlice.direct.readData") { benchmark in
+        let dir = BenchmarkFixtures.makeTempDirectory()
+        defer { BenchmarkFixtures.cleanup(dir) }
+        let url = dir.appendingPathComponent("file.bin")
+        BenchmarkFixtures.makeFile(at: url, size: BenchmarkFixtures.defaultFileSize)
+        let file = try StreamedFile.open(url: url, isWritable: false)
+        let sliceLength = file.size / 2
+        let slice = try file.fileSlice(
+            offset: file.size / 4,
+            length: sliceLength,
+            mode: .direct
+        )
+        let ranges = BenchmarkFixtures.readRanges(
+            size: sliceLength,
+            length: 4 * 1024,
+            count: 1_000
+        )
+
+        benchmark.startMeasurement()
+
+        for range in ranges {
+            blackHole(try slice.readData(offset: range.offset, length: range.length))
+        }
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "FileIOBenchmarks",
+    platforms: [
+        .macOS(.v13)
+    ],
+    dependencies: [
+        .package(path: ".."),
+        .package(url: "https://github.com/ordo-one/benchmark", from: "1.4.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "FileIOBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "benchmark"),
+                .product(name: "FileIO", package: "swift-fileio"),
+            ],
+            path: "Benchmarks/FileIOBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "benchmark")
+            ]
+        )
+    ]
+)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# Benchmarks
+#
+# Usage:
+#   make benchmark
+#   make benchmark BENCHMARK_ARGS='--filter MemoryMappedFile.readData'
+#   make benchmark-baseline-update BASELINE=main
+#   make benchmark-baseline-compare BASELINE=main
+
+BENCHMARK_DIR := Benchmarks
+BENCHMARK_ENV ?= BENCHMARK_DISABLE_JEMALLOC=1
+BENCHMARK_ARGS ?=
+BASELINE ?= main
+
+.PHONY: benchmark-build
+benchmark-build:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift build
+
+.PHONY: benchmark-list
+benchmark-list:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift package benchmark list
+
+.PHONY: benchmark
+benchmark:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift package benchmark $(BENCHMARK_ARGS)
+
+.PHONY: benchmark-baseline-update
+benchmark-baseline-update:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift package --allow-writing-to-package-directory benchmark baseline update $(BASELINE) $(BENCHMARK_ARGS)
+
+.PHONY: benchmark-baseline-compare
+benchmark-baseline-compare:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift package benchmark baseline compare $(BASELINE) $(BENCHMARK_ARGS)


### PR DESCRIPTION
## Summary
- Introduce a standalone SwiftPM package under `Benchmarks/` that depends on the local `swift-fileio` package and [`ordo-one/benchmark`](https://github.com/ordo-one/benchmark) (1.4.0+).
- Cover the read paths of `MemoryMappedFile`, `StreamedFile`, `ConcatenatedMemoryMappedFile`, and `ConcatenatedStreamedFile` — 18 benchmarks in total — measuring `open`, `readData`, typed `read<T>`, `readAllData`, `fileSlice` (including `buffered` vs `direct` for `StreamedFile`), and the segment lookup on the concatenated variants.
- Add a top-level `Makefile` with `benchmark-build`, `benchmark-list`, `benchmark`, `benchmark-baseline-update`, and `benchmark-baseline-compare` targets so baselines can be recorded and compared from the repo root.
- Ignore baseline / build artifacts (`Benchmarks/.benchmarkBaselines/`, `Benchmarks/.build/`, `Benchmarks/.swiftpm/`, `Benchmarks/Package.resolved`).

Inspired by [p-x9/MachOKit#287](https://github.com/p-x9/MachOKit/pull/287).

## Usage
```bash
make benchmark
make benchmark BENCHMARK_ARGS='--filter MemoryMappedFile'
make benchmark-baseline-update BASELINE=main
make benchmark-baseline-compare BASELINE=main