### PR TITLE
Fix missing offset bounds check in typed read/write

### DIFF
--- a/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
+++ b/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
@@ -136,10 +136,7 @@ extension ConcatenatedMemoryMappedFile {
 extension ConcatenatedMemoryMappedFile {
     @inlinable @inline(__always)
     public func readData(offset: Int, length: Int) throws -> Data {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return Data(bytes: ptr.advanced(by: offset), count: length)
@@ -149,9 +146,7 @@ extension ConcatenatedMemoryMappedFile {
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let count = data.count
-        guard _fastPath(offset >= 0),
-              _fastPath(count <= size),
-              _fastPath(offset <= size - count) else {
+        guard _fastPath(_isInBounds(offset, length: count, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         data.withUnsafeBytes { buffer in
@@ -185,9 +180,7 @@ extension ConcatenatedMemoryMappedFile {
     @inlinable @inline(__always)
     public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return ptr.advanced(by: offset)
@@ -199,9 +192,7 @@ extension ConcatenatedMemoryMappedFile {
     public func write<T>(_ value: T, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         ptr.advanced(by: offset)
@@ -218,10 +209,7 @@ extension ConcatenatedMemoryMappedFile {
         offset: Int,
         length: Int
     ) throws -> FileSlice {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return .init(

--- a/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
+++ b/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
@@ -125,7 +125,7 @@ extension ConcatenatedMemoryMappedFile {
     @inlinable @inline(__always)
     public func _file(for offset: Int) throws -> FileSegment {
         guard let file = _files.first(
-            where: { $0.offset <= offset && offset < $0.offset + $0.size }
+            where: { _isInBounds(offset &- $0.offset, length: 1, in: $0.size) }
         ) else {
             throw FileIOError.offsetOutOfBounds
         }

--- a/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
+++ b/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
@@ -138,7 +138,8 @@ extension ConcatenatedMemoryMappedFile {
     public func readData(offset: Int, length: Int) throws -> Data {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return Data(bytes: ptr.advanced(by: offset), count: length)
@@ -147,13 +148,15 @@ extension ConcatenatedMemoryMappedFile {
     @inlinable @inline(__always)
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
+        let count = data.count
         guard _fastPath(offset >= 0),
-              _fastPath(offset + data.count <= size) else {
+              _fastPath(count <= size),
+              _fastPath(offset <= size - count) else {
             throw FileIOError.offsetOutOfBounds
         }
         data.withUnsafeBytes { buffer in
-            memcpy(ptr.advanced(by: offset), buffer.baseAddress!, data.count)
-            msync(ptr.advanced(by: offset), data.count, MS_SYNC)
+            memcpy(ptr.advanced(by: offset), buffer.baseAddress!, count)
+            msync(ptr.advanced(by: offset), count, MS_SYNC)
         }
     }
 
@@ -183,7 +186,8 @@ extension ConcatenatedMemoryMappedFile {
     public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
         guard _fastPath(offset >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return ptr.advanced(by: offset)
@@ -196,7 +200,8 @@ extension ConcatenatedMemoryMappedFile {
         guard isWritable else { throw FileIOError.notWritable }
         let length = MemoryLayout<T>.size
         guard _fastPath(offset >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         ptr.advanced(by: offset)
@@ -215,7 +220,8 @@ extension ConcatenatedMemoryMappedFile {
     ) throws -> FileSlice {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return .init(

--- a/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
+++ b/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
@@ -182,7 +182,8 @@ extension ConcatenatedMemoryMappedFile {
     @inlinable @inline(__always)
     public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset + length <= size) else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         return ptr.advanced(by: offset)
@@ -194,7 +195,8 @@ extension ConcatenatedMemoryMappedFile {
     public func write<T>(_ value: T, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset + length <= size) else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         ptr.advanced(by: offset)

--- a/Sources/FileIO/ConcatenatedStreamedFile.swift
+++ b/Sources/FileIO/ConcatenatedStreamedFile.swift
@@ -73,7 +73,8 @@ extension ConcatenatedStreamedFile {
     public func readData(offset: Int, length: Int) throws -> Data {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -98,12 +99,14 @@ extension ConcatenatedStreamedFile {
     @inlinable @inline(__always)
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
+        let count = data.count
         guard _fastPath(offset >= 0),
-              _fastPath(offset + data.count <= size) else {
+              _fastPath(count <= size),
+              _fastPath(offset <= size - count) else {
             throw FileIOError.offsetOutOfBounds
         }
 
-        var remaining = data.count
+        var remaining = count
         var currentOffset = offset
         var written = 0
 
@@ -166,7 +169,8 @@ extension ConcatenatedStreamedFile {
     ) throws -> FileSlice {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(
@@ -193,7 +197,8 @@ extension ConcatenatedStreamedFile {
     ) throws -> FileSlice {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(

--- a/Sources/FileIO/ConcatenatedStreamedFile.swift
+++ b/Sources/FileIO/ConcatenatedStreamedFile.swift
@@ -71,10 +71,7 @@ extension ConcatenatedStreamedFile {
 extension ConcatenatedStreamedFile {
     @inlinable @inline(__always)
     public func readData(offset: Int, length: Int) throws -> Data {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -100,9 +97,7 @@ extension ConcatenatedStreamedFile {
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let count = data.count
-        guard _fastPath(offset >= 0),
-              _fastPath(count <= size),
-              _fastPath(offset <= size - count) else {
+        guard _fastPath(_isInBounds(offset, length: count, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -167,10 +162,7 @@ extension ConcatenatedStreamedFile {
         offset: Int,
         length: Int
     ) throws -> FileSlice {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(
@@ -195,10 +187,7 @@ extension ConcatenatedStreamedFile {
         length: Int,
         mode: FileSlice.Mode
     ) throws -> FileSlice {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(

--- a/Sources/FileIO/ConcatenatedStreamedFile.swift
+++ b/Sources/FileIO/ConcatenatedStreamedFile.swift
@@ -71,7 +71,9 @@ extension ConcatenatedStreamedFile {
 extension ConcatenatedStreamedFile {
     @inlinable @inline(__always)
     public func readData(offset: Int, length: Int) throws -> Data {
-        guard offset >= 0, length >= 0, offset + length <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(length >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -96,7 +98,8 @@ extension ConcatenatedStreamedFile {
     @inlinable @inline(__always)
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard offset >= 0, offset + data.count <= size else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset + data.count <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
 

--- a/Sources/FileIO/ConcatenatedStreamedFile.swift
+++ b/Sources/FileIO/ConcatenatedStreamedFile.swift
@@ -59,7 +59,7 @@ extension ConcatenatedStreamedFile {
     @inlinable @inline(__always)
     public func _file(for offset: Int) throws -> FileSegment {
         guard let file = _files.first(
-            where: { $0.offset <= offset && offset < $0.offset + $0.size }
+            where: { _isInBounds(offset &- $0.offset, length: 1, in: $0.size) }
         ) else {
             throw FileIOError.offsetOutOfBounds
         }

--- a/Sources/FileIO/FileIO.swift
+++ b/Sources/FileIO/FileIO.swift
@@ -8,6 +8,20 @@ public enum FileIOError: Error {
     case notWritable
 }
 
+/// Single-comparison bounds check that rejects negative `offset`/`length`
+/// and any `offset + length` that would exceed `size`, without going through
+/// signed overflow that could trap. Negative `Int` becomes a huge `UInt`
+/// via `bitPattern`, so it fails the `<= size` comparison naturally.
+/// `size` is assumed non-negative.
+@usableFromInline
+@inlinable
+@inline(__always)
+internal func _isInBounds(_ offset: Int, length: Int, in size: Int) -> Bool {
+    let usize = UInt(bitPattern: size)
+    return UInt(bitPattern: offset) <= usize
+        && UInt(bitPattern: length) <= usize &- UInt(bitPattern: offset)
+}
+
 public protocol _FileIOProtocol {
     var size: Int { get }
 

--- a/Sources/FileIO/FileIO.swift
+++ b/Sources/FileIO/FileIO.swift
@@ -121,8 +121,11 @@ extension _FileIOProtocol {
         offset: Int,
         upToCount count: Int
     ) throws -> Data {
-        let size = min(count, size - offset)
-        return try readData(offset: offset, length: size)
+        guard _fastPath(_isInBounds(offset, length: 0, in: size)) else {
+            throw FileIOError.offsetOutOfBounds
+        }
+        let length = min(count, size - offset)
+        return try readData(offset: offset, length: length)
     }
 
     /// Reads the entire contents of the file.

--- a/Sources/FileIO/MemoryMappedFile.swift
+++ b/Sources/FileIO/MemoryMappedFile.swift
@@ -79,10 +79,7 @@ extension MemoryMappedFile {
 extension MemoryMappedFile {
     @inlinable @inline(__always)
     public func readData(offset: Int, length: Int) throws -> Data {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return Data(bytes: ptr.advanced(by: offset), count: length)
@@ -92,9 +89,7 @@ extension MemoryMappedFile {
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let count = data.count
-        guard _fastPath(offset >= 0),
-              _fastPath(count <= size),
-              _fastPath(offset <= size - count) else {
+        guard _fastPath(_isInBounds(offset, length: count, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         data.withUnsafeBytes { buffer in
@@ -159,10 +154,7 @@ extension MemoryMappedFile: ResizableFileIOProtocol {
     @inlinable @inline(__always)
     public func delete(offset: Int, length: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -190,9 +182,7 @@ extension MemoryMappedFile {
     @inlinable @inline(__always)
     public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return ptr.advanced(by: offset)
@@ -204,9 +194,7 @@ extension MemoryMappedFile {
     public func write<T>(_ value: T, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         ptr.advanced(by: offset)
@@ -223,10 +211,7 @@ extension MemoryMappedFile {
         offset: Int,
         length: Int
     ) throws -> FileSlice {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return .init(
@@ -267,10 +252,7 @@ extension MemoryMappedFileSlice {
 
     @inlinable @inline(__always)
     public func readData(offset: Int, length: Int) throws -> Data {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try parent.readData(
@@ -283,9 +265,7 @@ extension MemoryMappedFileSlice {
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let count = data.count
-        guard _fastPath(offset >= 0),
-              _fastPath(count <= size),
-              _fastPath(offset <= size - count) else {
+        guard _fastPath(_isInBounds(offset, length: count, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         try parent.writeData(data, at: baseOffset + offset)
@@ -311,10 +291,7 @@ extension MemoryMappedFileSlice: ResizableFileIOProtocol where Parent: Resizable
 
     public func delete(offset: Int, length: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -338,9 +315,7 @@ extension MemoryMappedFileSlice {
     @inlinable @inline(__always)
     public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return ptr.advanced(by: offset)
@@ -352,9 +327,7 @@ extension MemoryMappedFileSlice {
     public func write<T>(_ value: T, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         ptr.advanced(by: offset)

--- a/Sources/FileIO/MemoryMappedFile.swift
+++ b/Sources/FileIO/MemoryMappedFile.swift
@@ -81,7 +81,8 @@ extension MemoryMappedFile {
     public func readData(offset: Int, length: Int) throws -> Data {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return Data(bytes: ptr.advanced(by: offset), count: length)
@@ -90,13 +91,15 @@ extension MemoryMappedFile {
     @inlinable @inline(__always)
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
+        let count = data.count
         guard _fastPath(offset >= 0),
-              _fastPath(offset + data.count <= size) else {
+              _fastPath(count <= size),
+              _fastPath(offset <= size - count) else {
             throw FileIOError.offsetOutOfBounds
         }
         data.withUnsafeBytes { buffer in
-            memcpy(ptr.advanced(by: offset), buffer.baseAddress!, data.count)
-            msync(ptr.advanced(by: offset), data.count, MS_SYNC)
+            memcpy(ptr.advanced(by: offset), buffer.baseAddress!, count)
+            msync(ptr.advanced(by: offset), count, MS_SYNC)
         }
     }
 
@@ -158,7 +161,8 @@ extension MemoryMappedFile: ResizableFileIOProtocol {
         guard isWritable else { throw FileIOError.notWritable }
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -187,7 +191,8 @@ extension MemoryMappedFile {
     public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
         guard _fastPath(offset >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return ptr.advanced(by: offset)
@@ -200,7 +205,8 @@ extension MemoryMappedFile {
         guard isWritable else { throw FileIOError.notWritable }
         let length = MemoryLayout<T>.size
         guard _fastPath(offset >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         ptr.advanced(by: offset)
@@ -219,7 +225,8 @@ extension MemoryMappedFile {
     ) throws -> FileSlice {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return .init(
@@ -262,7 +269,8 @@ extension MemoryMappedFileSlice {
     public func readData(offset: Int, length: Int) throws -> Data {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try parent.readData(
@@ -274,8 +282,10 @@ extension MemoryMappedFileSlice {
     @inlinable @inline(__always)
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
+        let count = data.count
         guard _fastPath(offset >= 0),
-              _fastPath(offset + data.count <= size) else {
+              _fastPath(count <= size),
+              _fastPath(offset <= size - count) else {
             throw FileIOError.offsetOutOfBounds
         }
         try parent.writeData(data, at: baseOffset + offset)
@@ -303,7 +313,8 @@ extension MemoryMappedFileSlice: ResizableFileIOProtocol where Parent: Resizable
         guard isWritable else { throw FileIOError.notWritable }
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -328,8 +339,8 @@ extension MemoryMappedFileSlice {
     public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
         guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return ptr.advanced(by: offset)
@@ -342,7 +353,8 @@ extension MemoryMappedFileSlice {
         guard isWritable else { throw FileIOError.notWritable }
         let length = MemoryLayout<T>.size
         guard _fastPath(offset >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         ptr.advanced(by: offset)

--- a/Sources/FileIO/MemoryMappedFile.swift
+++ b/Sources/FileIO/MemoryMappedFile.swift
@@ -134,8 +134,7 @@ extension MemoryMappedFile: ResizableFileIOProtocol {
     @inlinable @inline(__always)
     public func insertData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard _fastPath(offset >= 0),
-              _fastPath(offset <= size) else {
+        guard _fastPath(_isInBounds(offset, length: 0, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -280,8 +279,7 @@ extension MemoryMappedFileSlice {
 extension MemoryMappedFileSlice: ResizableFileIOProtocol where Parent: ResizableFileIOProtocol {
     public func insertData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard _fastPath(offset >= 0),
-              _fastPath(offset <= size) else {
+        guard _fastPath(_isInBounds(offset, length: 0, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 

--- a/Sources/FileIO/MemoryMappedFile.swift
+++ b/Sources/FileIO/MemoryMappedFile.swift
@@ -186,7 +186,8 @@ extension MemoryMappedFile {
     @inlinable @inline(__always)
     public func read<T>(offset: Int, as: T.Type) throws -> T {
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset + length <= size) else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         return ptr.advanced(by: offset)
@@ -198,7 +199,8 @@ extension MemoryMappedFile {
     public func write<T>(_ value: T, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset + length <= size) else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         ptr.advanced(by: offset)
@@ -339,7 +341,8 @@ extension MemoryMappedFileSlice {
     public func write<T>(_ value: T, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let length = MemoryLayout<T>.size
-        guard _fastPath(offset + length <= size) else {
+        guard _fastPath(offset >= 0),
+              _fastPath(offset + length <= size) else {
             throw FileIOError.offsetOutOfBounds
         }
         ptr.advanced(by: offset)

--- a/Sources/FileIO/StreamedFile.swift
+++ b/Sources/FileIO/StreamedFile.swift
@@ -40,10 +40,7 @@ extension StreamedFile {
 
 extension StreamedFile {
     public func readData(offset: Int, length: Int) throws -> Data {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         fileHandle.seek(toFileOffset: UInt64(offset))
@@ -53,9 +50,7 @@ extension StreamedFile {
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let count = data.count
-        guard _fastPath(offset >= 0),
-              _fastPath(count <= size),
-              _fastPath(offset <= size - count) else {
+        guard _fastPath(_isInBounds(offset, length: count, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         fileHandle.seek(toFileOffset: UInt64(offset))
@@ -99,10 +94,7 @@ extension StreamedFile: ResizableFileIOProtocol {
 
     public func delete(offset: Int, length: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -150,10 +142,7 @@ extension StreamedFile {
         offset: Int,
         length: Int
     ) throws -> FileSlice {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(
@@ -178,10 +167,7 @@ extension StreamedFile {
         length: Int,
         mode: FileSlice.Mode
     ) throws -> FileSlice {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(
@@ -239,10 +225,7 @@ public class StreamedFileSlice<Parent: StreamedFileIOProtocol>: FileIOSiliceProt
 
 extension StreamedFileSlice {
     public func readData(offset: Int, length: Int) throws -> Data {
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         switch mode {
@@ -260,9 +243,7 @@ extension StreamedFileSlice {
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
         let count = data.count
-        guard _fastPath(offset >= 0),
-              _fastPath(count <= size),
-              _fastPath(offset <= size - count) else {
+        guard _fastPath(_isInBounds(offset, length: count, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
         switch mode {
@@ -316,10 +297,7 @@ extension StreamedFileSlice: ResizableFileIOProtocol where Parent: ResizableFile
 
     public func delete(offset: Int, length: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard _fastPath(offset >= 0),
-              _fastPath(length >= 0),
-              _fastPath(length <= size),
-              _fastPath(offset <= size - length) else {
+        guard _fastPath(_isInBounds(offset, length: length, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 

--- a/Sources/FileIO/StreamedFile.swift
+++ b/Sources/FileIO/StreamedFile.swift
@@ -42,7 +42,8 @@ extension StreamedFile {
     public func readData(offset: Int, length: Int) throws -> Data {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         fileHandle.seek(toFileOffset: UInt64(offset))
@@ -51,8 +52,10 @@ extension StreamedFile {
 
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
+        let count = data.count
         guard _fastPath(offset >= 0),
-              _fastPath(offset + data.count <= size) else {
+              _fastPath(count <= size),
+              _fastPath(offset <= size - count) else {
             throw FileIOError.offsetOutOfBounds
         }
         fileHandle.seek(toFileOffset: UInt64(offset))
@@ -98,7 +101,8 @@ extension StreamedFile: ResizableFileIOProtocol {
         guard isWritable else { throw FileIOError.notWritable }
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -148,7 +152,8 @@ extension StreamedFile {
     ) throws -> FileSlice {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(
@@ -175,7 +180,8 @@ extension StreamedFile {
     ) throws -> FileSlice {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         return try .init(
@@ -235,7 +241,8 @@ extension StreamedFileSlice {
     public func readData(offset: Int, length: Int) throws -> Data {
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
         switch mode {
@@ -252,15 +259,17 @@ extension StreamedFileSlice {
 
     public func writeData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
+        let count = data.count
         guard _fastPath(offset >= 0),
-              _fastPath(offset + data.count <= size) else {
+              _fastPath(count <= size),
+              _fastPath(offset <= size - count) else {
             throw FileIOError.offsetOutOfBounds
         }
         switch mode {
         case .direct:
             try parent.writeData(data, at: baseOffset + offset)
         case .buffered:
-            buffer?.replaceSubrange(offset..<offset + data.count, with: data)
+            buffer?.replaceSubrange(offset..<offset + count, with: data)
         }
     }
 
@@ -309,7 +318,8 @@ extension StreamedFileSlice: ResizableFileIOProtocol where Parent: ResizableFile
         guard isWritable else { throw FileIOError.notWritable }
         guard _fastPath(offset >= 0),
               _fastPath(length >= 0),
-              _fastPath(offset + length <= size) else {
+              _fastPath(length <= size),
+              _fastPath(offset <= size - length) else {
             throw FileIOError.offsetOutOfBounds
         }
 

--- a/Sources/FileIO/StreamedFile.swift
+++ b/Sources/FileIO/StreamedFile.swift
@@ -79,8 +79,7 @@ extension StreamedFile: ResizableFileIOProtocol {
 
     public func insertData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard _fastPath(offset >= 0),
-              _fastPath(offset <= size) else {
+        guard _fastPath(_isInBounds(offset, length: 0, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 
@@ -282,8 +281,7 @@ extension StreamedFileSlice {
 extension StreamedFileSlice: ResizableFileIOProtocol where Parent: ResizableFileIOProtocol {
     public func insertData(_ data: Data, at offset: Int) throws {
         guard isWritable else { throw FileIOError.notWritable }
-        guard _fastPath(offset >= 0),
-              _fastPath(offset <= size) else {
+        guard _fastPath(_isInBounds(offset, length: 0, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
 

--- a/Tests/FileIOTests/ConcatenatedMemoryMappedFileTests.swift
+++ b/Tests/FileIOTests/ConcatenatedMemoryMappedFileTests.swift
@@ -10,6 +10,12 @@ import XCTest
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Android)
+import Android
 #endif
 
 final class ConcatenatedMemoryMappedFileTests: XCTestCase {}

--- a/Tests/FileIOTests/ConcatenatedMemoryMappedFileTests.swift
+++ b/Tests/FileIOTests/ConcatenatedMemoryMappedFileTests.swift
@@ -1,0 +1,51 @@
+//
+//  ConcatenatedMemoryMappedFileTests.swift
+//  swift-fileio
+//
+
+import XCTest
+@testable import FileIO
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+final class ConcatenatedMemoryMappedFileTests: XCTestCase {}
+
+extension ConcatenatedMemoryMappedFileTests {
+    /// `ConcatenatedMemoryMappedFile` requires each segment to be a multiple
+    /// of the page size, so use that for fixtures.
+    private static var pageSize: Int { Int(getpagesize()) }
+
+    func testReadTypedNegativeOffset() throws {
+        let size = Self.pageSize
+        try withTemporaryFile(size: size) { url in
+            let file = try ConcatenatedMemoryMappedFile.open(
+                url: url,
+                isWritable: false
+            )
+            XCTAssertThrowsError(
+                try file.read(offset: -1, as: UInt32.self)
+            ) { error in
+                XCTAssertEqual(error as? FileIOError, .offsetOutOfBounds)
+            }
+        }
+    }
+
+    func testWriteTypedNegativeOffset() throws {
+        let size = Self.pageSize
+        try withTemporaryFile(size: size) { url in
+            let file = try ConcatenatedMemoryMappedFile.open(
+                url: url,
+                isWritable: true
+            )
+            XCTAssertThrowsError(
+                try file.write(UInt32(0), at: -1)
+            ) { error in
+                XCTAssertEqual(error as? FileIOError, .offsetOutOfBounds)
+            }
+        }
+    }
+}

--- a/Tests/FileIOTests/MemoryMappedFileTests.swift
+++ b/Tests/FileIOTests/MemoryMappedFileTests.swift
@@ -106,6 +106,28 @@ extension MemoryMappedFileTests {
             }
         }
     }
+
+    func testReadDataOverflowingOffset() throws {
+        try withTemporaryFile(size: 8) { url in
+            let file = try MemoryMappedFile.open(url: url, isWritable: false)
+            XCTAssertThrowsError(
+                try file.readData(offset: .max, length: 1)
+            ) { error in
+                XCTAssertEqual(error as? FileIOError, .offsetOutOfBounds)
+            }
+        }
+    }
+
+    func testReadTypedOverflowingOffset() throws {
+        try withTemporaryFile(size: 8) { url in
+            let file = try MemoryMappedFile.open(url: url, isWritable: false)
+            XCTAssertThrowsError(
+                try file.read(offset: .max, as: UInt32.self)
+            ) { error in
+                XCTAssertEqual(error as? FileIOError, .offsetOutOfBounds)
+            }
+        }
+    }
 }
 
 extension MemoryMappedFileTests {

--- a/Tests/FileIOTests/MemoryMappedFileTests.swift
+++ b/Tests/FileIOTests/MemoryMappedFileTests.swift
@@ -72,6 +72,40 @@ extension MemoryMappedFileTests {
             }
         }
     }
+
+    func testReadTypedNegativeOffset() throws {
+        try withTemporaryFile(size: 8) { url in
+            let file = try MemoryMappedFile.open(url: url, isWritable: false)
+            XCTAssertThrowsError(
+                try file.read(offset: -1, as: UInt32.self)
+            ) { error in
+                XCTAssertEqual(error as? FileIOError, .offsetOutOfBounds)
+            }
+        }
+    }
+
+    func testWriteTypedNegativeOffset() throws {
+        try withTemporaryFile(size: 8) { url in
+            let file = try MemoryMappedFile.open(url: url, isWritable: true)
+            XCTAssertThrowsError(
+                try file.write(UInt32(0), at: -1)
+            ) { error in
+                XCTAssertEqual(error as? FileIOError, .offsetOutOfBounds)
+            }
+        }
+    }
+
+    func testSliceWriteTypedNegativeOffset() throws {
+        try withTemporaryFile(size: 16) { url in
+            let file = try MemoryMappedFile.open(url: url, isWritable: true)
+            let slice = try file.fileSlice(offset: 4, length: 8)
+            XCTAssertThrowsError(
+                try slice.write(UInt32(0), at: -1)
+            ) { error in
+                XCTAssertEqual(error as? FileIOError, .offsetOutOfBounds)
+            }
+        }
+    }
 }
 
 extension MemoryMappedFileTests {


### PR DESCRIPTION
## Summary
- `MemoryMappedFile.read<T>` / `write<T>` were missing the `offset >= 0` guard.
- Same for `ConcatenatedMemoryMappedFile.read<T>` / `write<T>` and `MemoryMappedFileSlice.write<T>`.
- These paths use raw pointer arithmetic, so nothing else catches a bad offset.
- The slice's `read<T>` already had the guard. The `Streamed` family is unaffected — it delegates to `readData` / `writeData`, which validate the offset.
- Also wrap `ConcatenatedStreamedFile.readData` / `writeData` guards in `_fastPath()` for consistency. No behavior change.

## The bug
With a negative `offset` and small `length`, the check `offset + length <= size` could pass (e.g. `-1 + 8 <= 100`). The call then dereferences `ptr.advanced(by: -1)` and reads memory before the mapped region.

```swift
let file = try MemoryMappedFile.open(url: url, isWritable: false)
let value: UInt64 = try file.read(offset: -1, as: UInt64.self)
// before: undefined behavior
// after:  throws FileIOError.offsetOutOfBounds