### PR TITLE
Fix crash on empty Data in mmap write paths

### DIFF
--- a/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
+++ b/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
@@ -149,6 +149,7 @@ extension ConcatenatedMemoryMappedFile {
         guard _fastPath(_isInBounds(offset, length: count, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
+        guard count > 0 else { return }
         data.withUnsafeBytes { buffer in
             memcpy(ptr.advanced(by: offset), buffer.baseAddress!, count)
             msync(ptr.advanced(by: offset), count, MS_SYNC)

--- a/Sources/FileIO/MemoryMappedFile.swift
+++ b/Sources/FileIO/MemoryMappedFile.swift
@@ -92,6 +92,7 @@ extension MemoryMappedFile {
         guard _fastPath(_isInBounds(offset, length: count, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
+        guard count > 0 else { return }
         data.withUnsafeBytes { buffer in
             memcpy(ptr.advanced(by: offset), buffer.baseAddress!, count)
             msync(ptr.advanced(by: offset), count, MS_SYNC)
@@ -137,16 +138,18 @@ extension MemoryMappedFile: ResizableFileIOProtocol {
         guard _fastPath(_isInBounds(offset, length: 0, in: size)) else {
             throw FileIOError.offsetOutOfBounds
         }
+        let count = data.count
+        guard count > 0 else { return }
 
-        let newSize = size + data.count
+        let newSize = size + count
         try resize(newSize: newSize)
 
-        let tailSize = size - offset - data.count
-        memmove(ptr.advanced(by: offset + data.count), ptr.advanced(by: offset), tailSize)
+        let tailSize = size - offset - count
+        memmove(ptr.advanced(by: offset + count), ptr.advanced(by: offset), tailSize)
 
         data.withUnsafeBytes { buffer in
-            memcpy(ptr.advanced(by: offset), buffer.baseAddress!, data.count)
-            msync(ptr.advanced(by: offset), data.count + tailSize, MS_SYNC)
+            memcpy(ptr.advanced(by: offset), buffer.baseAddress!, count)
+            msync(ptr.advanced(by: offset), count + tailSize, MS_SYNC)
         }
     }
 

--- a/Tests/FileIOTests/ConcatenatedMemoryMappedFileTests.swift
+++ b/Tests/FileIOTests/ConcatenatedMemoryMappedFileTests.swift
@@ -54,4 +54,18 @@ extension ConcatenatedMemoryMappedFileTests {
             }
         }
     }
+
+    func testWriteEmptyData() throws {
+        let size = Self.pageSize
+        let initial = Data(repeating: 0xAB, count: size)
+        try withTemporaryFile(size: size, contents: initial) { url in
+            let file = try ConcatenatedMemoryMappedFile.open(
+                url: url,
+                isWritable: true
+            )
+            try file.writeData(Data(), at: 16)
+            file.sync()
+            XCTAssertEqual(try Data(contentsOf: url), initial)
+        }
+    }
 }

--- a/Tests/FileIOTests/MemoryMappedFileTests.swift
+++ b/Tests/FileIOTests/MemoryMappedFileTests.swift
@@ -128,6 +128,27 @@ extension MemoryMappedFileTests {
             }
         }
     }
+
+    func testWriteEmptyData() throws {
+        let initial = Data([1, 2, 3, 4])
+        try withTemporaryFile(size: initial.count, contents: initial) { url in
+            let file = try MemoryMappedFile.open(url: url, isWritable: true)
+            try file.writeData(Data(), at: 2)
+            file.sync()
+            XCTAssertEqual(try Data(contentsOf: url), initial)
+        }
+    }
+
+    func testInsertEmptyData() throws {
+        let initial = Data([1, 2, 3, 4])
+        try withTemporaryFile(size: initial.count, contents: initial) { url in
+            let file = try MemoryMappedFile.open(url: url, isWritable: true)
+            try file.insertData(Data(), at: 2)
+            file.sync()
+            XCTAssertEqual(file.size, initial.count)
+            XCTAssertEqual(try Data(contentsOf: url), initial)
+        }
+    }
 }
 
 extension MemoryMappedFileTests {


### PR DESCRIPTION
## Summary
`MemoryMappedFile.writeData`, `MemoryMappedFile.insertData`, and `ConcatenatedMemoryMappedFile.writeData` use `data.withUnsafeBytes { buffer in memcpy(..., buffer.baseAddress!, ...) }`. 
When `data` is empty, `buffer.baseAddress` can be `nil` (documented behavior of `UnsafeRawBufferPointer`), so the force-unwrap crashes.

## Fix
Add `guard count > 0 else { return }` after the bounds check at each site. 
The bounds check still runs first, so an invalid offset on empty `Data` still throws `offsetOutOfBounds` as before.

In `insertData`, `data.count` is now hoisted to a local since the value is referenced multiple times.

## Reproduction (before this fix)
```swift
let file = try MemoryMappedFile.open(url: url, isWritable: true)
try file.writeData(Data(), at: 0)
// → crash on baseAddress!