### PR TITLE
Add an experimental Windows build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,25 +135,30 @@ jobs:
         run: swift build -v --swift-sdk ${{ matrix.target.sdk }} ${{ matrix.target.build-option }}
 
   windows-build:
-    name: Windows (${{ matrix.tag }})
+    name: Windows
     runs-on: windows-2025
-    # Visibility only. Windows has no mmap, so MemoryMappedFile and
-    # ConcatenatedMemoryMappedFile are not expected to compile. This job
-    # exists to measure what actually breaks -- in particular whether the
-    # FileHandle-based StreamedFile types build unchanged -- rather than
-    # guess at it while planning Windows support.
+    # Visibility only. MemoryMappedFile and ConcatenatedMemoryMappedFile do
+    # not compile: Windows has no mmap/munmap/msync/ftruncate and none of the
+    # MAP_*/PROT_*/MS_SYNC constants. The FileHandle-based StreamedFile types
+    # and FileIO.swift do build clean, so this job tracks that the Windows gap
+    # stays confined to the two mapping types.
     continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        tag: [windowsservercore-ltsc2022]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Read .swift-version
+        id: swift-version
+        shell: bash
+        run: echo "version=$(cat .swift-version | xargs)" >> "$GITHUB_OUTPUT"
+
+      - name: Install Swift
+        uses: SwiftyLab/setup-swift@v1.14.0
+        with:
+          swift-version: ${{ steps.swift-version.outputs.version }}
+
+      - name: Show Swift version
+        run: swift --version
+
       - name: Build
-        run: |
-          $version = (Get-Content .swift-version).Trim()
-          $image = "swift:$version-${{ matrix.tag }}"
-          docker run --rm $image swift --version
-          docker run --rm -v "${{ github.workspace }}:C:\workspace" -w "C:\workspace" $image swift build -v
+        run: swift build -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,27 @@ jobs:
 
       - name: Build
         run: swift build -v --swift-sdk ${{ matrix.target.sdk }} ${{ matrix.target.build-option }}
+
+  windows-build:
+    name: Windows (${{ matrix.tag }})
+    runs-on: windows-2025
+    # Visibility only. Windows has no mmap, so MemoryMappedFile and
+    # ConcatenatedMemoryMappedFile are not expected to compile. This job
+    # exists to measure what actually breaks -- in particular whether the
+    # FileHandle-based StreamedFile types build unchanged -- rather than
+    # guess at it while planning Windows support.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: [windowsservercore-ltsc2022]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: |
+          $version = (Get-Content .swift-version).Trim()
+          $image = "swift:$version-${{ matrix.tag }}"
+          docker run --rm $image swift --version
+          docker run --rm -v "${{ github.workspace }}:C:\workspace" -w "C:\workspace" $image swift build -v


### PR DESCRIPTION
Follow-up to #26. Measures the Windows gap instead of guessing at it.

## Result: the gap is confined to the two mapping types

| File | Errors |
|---|---|
| `MemoryMappedFile.swift` | 66 |
| `ConcatenatedMemoryMappedFile.swift` | 40 |
| `StreamedFile.swift` | **0** |
| `ConcatenatedStreamedFile.swift` | **0** |
| `FileIO.swift` | **0** |

The `FileHandle`-based types compile clean on Windows, so Windows support is a mapping-layer problem only. Every unresolved symbol is mapping-related:

```
mmap munmap msync ftruncate MS_SYNC MAP_ANONYMOUS MAP_FAILED
MAP_FIXED MAP_PRIVATE MAP_SHARED PROT_NONE PROT_READ PROT_WRITE
```

Two findings worth carrying into the `system.swift` work:

1. **Windows and Android need differently-shaped shims.** On Windows `errno`, `close`, `lseek`, `O_RDONLY` and `O_RDWR` all resolve (via ucrt). On Android none of them do (#26). A single POSIX shim shape will not cover both.

2. **The `_open` shim name collides on Windows.** `system.swift` has no Windows branch, so `_open` resolves to the MSVC CRT `_open`, which Swift cannot import:
   ```
   error: _open is unavailable: Variadic function is unavailable
   ```
   The shim needs a name that cannot collide with a CRT symbol.

## Why native rather than a container

Started with the official Swift Windows container, then switched. Both produce identical diagnostics, but:

| | Container | Native |
|---|---|---|
| Total | 9m49s | **3m28s** |
| Toolchain | 9m32s (multi-GB image pull) | 2m43s |
| Compile | seconds | 29s |

Native also matches how Windows users actually build. Toolchain version comes from `.swift-version`, so pinning stays in one place.

## Scope

`continue-on-error: true`, matching how the Android targets are handled in #26 — the job reports without failing the workflow. It is expected to fail until the mapping layer gains a Windows backend; its value is keeping the gap measured, so a regression that spreads Windows breakage beyond these two files shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)