### PR TITLE
Fix silently lost writes in ConcatenatedMemoryMappedFile

### DIFF
--- a/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
+++ b/Sources/FileIO/ConcatenatedMemoryMappedFile.swift
@@ -87,7 +87,12 @@ extension ConcatenatedMemoryMappedFile {
         for (fd, size) in fdAndSizes {
             let size: Int = numericCast(size)
             let ptr = basePtr.advanced(by: offset)
-            let mappedPtr = mmap(ptr, size, prot, MAP_FIXED | MAP_PRIVATE, fd, 0)
+            // MAP_SHARED, not MAP_PRIVATE: a private mapping keeps writes in
+            // copy-on-write pages that never reach the file, and msync is a
+            // no-op for it, so writes would be silently lost. The anonymous
+            // reservation above stays private -- it only holds the address
+            // range these segments are then mapped into.
+            let mappedPtr = mmap(ptr, size, prot, MAP_FIXED | MAP_SHARED, fd, 0)
             guard ptr == mappedPtr,
                   _fastPath(ptr != MAP_FAILED) else {
                 cleanup(fds: fdAndSizes.map(\.fd))

--- a/Tests/FileIOTests/ConcatenatedMemoryMappedFileTests.swift
+++ b/Tests/FileIOTests/ConcatenatedMemoryMappedFileTests.swift
@@ -68,4 +68,87 @@ extension ConcatenatedMemoryMappedFileTests {
             XCTAssertEqual(try Data(contentsOf: url), initial)
         }
     }
+
+    /// Reads the file back through the filesystem rather than through the
+    /// mapping, so a mapping that never writes through cannot pass.
+    func testWriteDataPersistsToDisk() throws {
+        let size = Self.pageSize
+        try withTemporaryFile(
+            size: size,
+            contents: Data(repeating: 0xAB, count: size)
+        ) { url in
+            let file = try ConcatenatedMemoryMappedFile.open(
+                url: url,
+                isWritable: true
+            )
+            let payload = Data([0x01, 0x02, 0x03, 0x04])
+            try file.writeData(payload, at: 16)
+            file.sync()
+
+            let onDisk = try Data(contentsOf: url)
+            XCTAssertEqual(onDisk.count, size)
+            XCTAssertEqual(onDisk[16..<20], payload)
+            XCTAssertEqual(onDisk[0..<16], Data(repeating: 0xAB, count: 16))
+        }
+    }
+
+    func testWriteTypedPersistsToDisk() throws {
+        let size = Self.pageSize
+        try withTemporaryFile(
+            size: size,
+            contents: Data(repeating: 0, count: size)
+        ) { url in
+            let file = try ConcatenatedMemoryMappedFile.open(
+                url: url,
+                isWritable: true
+            )
+            try file.write(UInt32(0xDEADBEEF), at: 32)
+            file.sync()
+
+            let onDisk = try Data(contentsOf: url)
+            let readBack = onDisk[32..<36].withUnsafeBytes {
+                $0.loadUnaligned(as: UInt32.self)
+            }
+            XCTAssertEqual(readBack, 0xDEADBEEF)
+        }
+    }
+
+    /// A write straddling the seam between two mapped files must land in both
+    /// of them, which is the whole point of the concatenated mapping.
+    func testWriteAcrossSegmentBoundaryPersistsToDisk() throws {
+        let size = Self.pageSize
+        try withTemporaryFiles(
+            files: [
+                (size: size, contents: Data(repeating: 0xAA, count: size)),
+                (size: size, contents: Data(repeating: 0xBB, count: size)),
+            ]
+        ) { urls in
+            let file = try ConcatenatedMemoryMappedFile.open(
+                urls: urls,
+                isWritable: true
+            )
+            XCTAssertEqual(file.size, size * 2)
+
+            // Two bytes before the seam, two bytes after it.
+            let payload = Data([0x01, 0x02, 0x03, 0x04])
+            try file.writeData(payload, at: size - 2)
+            file.sync()
+
+            let first = try Data(contentsOf: urls[0])
+            let second = try Data(contentsOf: urls[1])
+
+            XCTAssertEqual(first[(size - 2)..<size], payload[0..<2])
+            XCTAssertEqual(second[0..<2], payload[2..<4])
+
+            // Everything outside the written range is untouched.
+            XCTAssertEqual(
+                first[0..<(size - 2)],
+                Data(repeating: 0xAA, count: size - 2)
+            )
+            XCTAssertEqual(
+                second[2..<size],
+                Data(repeating: 0xBB, count: size - 2)
+            )
+        }
+    }
 }


### PR DESCRIPTION
Writes through `ConcatenatedMemoryMappedFile` never reached the file. No error, no diagnostic — the bytes were just gone.

## Cause

Segments were mapped with `MAP_FIXED | MAP_PRIVATE` even when opened writable ([`ConcatenatedMemoryMappedFile.swift:90`](https://github.com/p-x9/swift-fileio/blob/main/Sources/FileIO/ConcatenatedMemoryMappedFile.swift#L90)). A private mapping keeps writes in copy-on-write pages that never reach the file, and `msync` is a no-op for it — so `writeData` and `write<T>` both succeeded and discarded the data.

`MemoryMappedFile` has used `MAP_SHARED` since 6ebc6fe, the same commit that introduced this type. The flag looks carried down from the anonymous reservation immediately above, which legitimately needs `MAP_PRIVATE | MAP_ANONYMOUS` since it only reserves the address range the segments are then mapped into. That reservation is unchanged.

## Why no test caught it

The three existing tests covered negative offsets and the empty-`Data` no-op, and read back **through the same mapping** — where copy-on-write pages faithfully return the bytes just written, so the write appears to have worked. Nothing read through the filesystem.

The added tests do:

| Test | What it pins down |
|---|---|
| `testWriteDataPersistsToDisk` | `writeData` reaches the file; surrounding bytes untouched |
| `testWriteTypedPersistsToDisk` | `write<T>` reaches the file |
| `testWriteAcrossSegmentBoundaryPersistsToDisk` | a write straddling the seam lands in **both** files, in the right halves |

Before the fix, 3 of them fail — most legibly `testWriteTypedPersistsToDisk`, which reads back `0` instead of `0xDEADBEEF`. After, all 44 tests pass.

## Read-only path is unaffected

`ConcatenatedMemoryMappedFile` is used read-only to place the dyld shared cache and its subcaches in one contiguous address space, so that path matters more than the writable one. Verified directly rather than assumed — mapping `dyld_shared_cache_arm64e` (2,712,502,272 bytes) plus its `.01` subcache (2,202,206,208) under both flags:

| | `MAP_PRIVATE` | `MAP_SHARED` |
|---|---|---|
| `size` | 4,914,708,480 | identical |
| magic at offset 0 | `"dyld_v1  arm64e"` | identical |
| bytes either side of the seam | match the individual files | identical |
| subcache magic at the seam | `"dyld_v1  arm64e"` | identical |

With `isWritable: false` the protection is `PROT_READ` only, so no write ever happens and the two flags differ solely in external-modification visibility and physical page sharing — neither of which affects parsing a static file.

## Note

`MAP_PRIVATE` + `PROT_WRITE` on an `O_RDONLY` fd is a legitimate mode — it is how you apply rebases or chained fixups to a mapped image in memory and read the result without any risk of touching the file. The current `isWritable: Bool` API cannot express it. That is a feature worth adding deliberately (e.g. `.readOnly` / `.copyOnWrite` / `.shared`), not the behaviour that should be sitting on the writable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)